### PR TITLE
Enable phantomjs to restart

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "saintberry/phantomjs-extension",
+    "name": "dennisdigital/phantomjs-extension",
     "description": "Adds a PhantomJs driver to Behat's Mink extension. This will automatically start and stop PhantomJs in your tests.",
     "license": "MIT",
     "authors": [
@@ -15,7 +15,7 @@
     "require-dev": {
         "behat/behat": "~3.0",
         "behat/mink": "~1.5",
-        "behat/mink-extension": "~2.0"  
+        "behat/mink-extension": "~2.0"
     },
     "autoload": {
         "psr-0": { "Behat\\PhantomJsExtension": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "dennisdigital/phantomjs-extension",
+    "name": "saintberry/phantomjs-extension",
     "description": "Adds a PhantomJs driver to Behat's Mink extension. This will automatically start and stop PhantomJs in your tests.",
     "license": "MIT",
     "authors": [

--- a/src/Behat/PhantomJsExtension/Driver/PhantomJsDriver.php
+++ b/src/Behat/PhantomJsExtension/Driver/PhantomJsDriver.php
@@ -81,5 +81,6 @@ class PhantomJsDriver extends Selenium2Driver
     {
         parent::stop();
         $this->phantomJsProc->stop(0);
+        unset($this->phantomJsProc);
     }
 }

--- a/src/Behat/PhantomJsExtension/Driver/PhantomJsDriver.php
+++ b/src/Behat/PhantomJsExtension/Driver/PhantomJsDriver.php
@@ -68,9 +68,7 @@ class PhantomJsDriver extends Selenium2Driver
         if (!$this->phantomJsProc->isRunning()) {
             throw new DriverException('Could not confirm PhantomJs is running');
         }
-
-        // give PhantomJs a chance to start before creating a session
-        sleep(1);
+        
         parent::start();
     }
 

--- a/src/Behat/PhantomJsExtension/Driver/PhantomJsDriver.php
+++ b/src/Behat/PhantomJsExtension/Driver/PhantomJsDriver.php
@@ -54,10 +54,12 @@ class PhantomJsDriver extends Selenium2Driver
             return parent::start();
         }
 
-        $cmd = sprintf('exec %s --webdriver=%d', $this->phantomJsBin, $this->wdPort);
+        $cmd = sprintf('exec %s --webdriver=%d /dev/null 2>&1', $this->phantomJsBin, $this->wdPort);
 
         try {
             $this->phantomJsProc = new Process($cmd);
+            $this->phantomJsProc->disableOutput();
+            $this->phantomJsProc->setTimeout(600);
             $this->phantomJsProc->start();
         } catch (\Exception $e) {
             throw new DriverException('Could not start PhantomJs', 0, $e);

--- a/src/Behat/PhantomJsExtension/Driver/PhantomJsDriver.php
+++ b/src/Behat/PhantomJsExtension/Driver/PhantomJsDriver.php
@@ -40,9 +40,7 @@ class PhantomJsDriver extends Selenium2Driver
         $wdPort = 8643,
         $bin = '/usr/local/bin/phantomjs'
     ) {
-        $this->setBrowserName($browserName);
-        $this->setDesiredCapabilities($desiredCapabilities);
-        $this->setWebDriver(new WebDriver($wdHost));
+        parent::__construct($browserName, $desiredCapabilities, $wdHost);
         $this->wdPort = $wdPort;
         $this->phantomJsBin = $bin;
     }

--- a/src/Behat/PhantomJsExtension/Driver/PhantomJsDriver.php
+++ b/src/Behat/PhantomJsExtension/Driver/PhantomJsDriver.php
@@ -68,7 +68,7 @@ class PhantomJsDriver extends Selenium2Driver
         if (!$this->phantomJsProc->isRunning()) {
             throw new DriverException('Could not confirm PhantomJs is running');
         }
-        
+        sleep(1);
         parent::start();
     }
 

--- a/src/Behat/PhantomJsExtension/Driver/PhantomJsDriver.php
+++ b/src/Behat/PhantomJsExtension/Driver/PhantomJsDriver.php
@@ -81,6 +81,6 @@ class PhantomJsDriver extends Selenium2Driver
     {
         parent::stop();
         $this->phantomJsProc->stop(0);
-        unset($this->phantomJsProc);
+        $this->phantomJsProc = null;
     }
 }


### PR DESCRIPTION
This branch includes changes from the xpath branch and sets phantomJsProc to null enabling PhantomJS to be started and stopped before and after each scenario.
PhantomJS output is now quiet. As an improvement these should be optional settings controlled from behat.yml.